### PR TITLE
Fix 500 error when Verb of interest + Non-Interesting Http Status Code

### DIFF
--- a/ApplicationInsightsRequestLogging/ApplicationInsightsRequestLogging/BodyLoggerMiddleware.cs
+++ b/ApplicationInsightsRequestLogging/ApplicationInsightsRequestLogging/BodyLoggerMiddleware.cs
@@ -41,6 +41,10 @@ namespace Azureblue.ApplicationInsights.RequestLogging
                     _telemetryWriter.Write(context, _options.Value.RequestBodyPropertyKey, requestBody);
                     _telemetryWriter.Write(context, _options.Value.ResponseBodyPropertyKey, responseBody);
                 }
+                
+                // Copy back so response body is available for the user agent
+                // prevent 500 error when Not StatusCode of Interest
+                await this._bodyReader.RestoreOriginalResponseBodyStreamAsync(context);
             }
         }
     }

--- a/ApplicationInsightsRequestLogging/ApplicationInsightsRequestLogging/Extensions/ServiceCollectionExtensions.cs
+++ b/ApplicationInsightsRequestLogging/ApplicationInsightsRequestLogging/Extensions/ServiceCollectionExtensions.cs
@@ -37,9 +37,9 @@ namespace Azureblue.ApplicationInsights.RequestLogging
 
         internal static void AddBodyLogger(IServiceCollection services)
         {
-            services.AddTransient<BodyLoggerMiddleware>();
-            services.AddTransient<IBodyReader, BodyReader>();
-            services.AddTransient<ITelemetryWriter, TelemetryWriter>();
+            services.AddScoped<BodyLoggerMiddleware>();
+            services.AddScoped<IBodyReader, BodyReader>();
+            services.AddScoped<ITelemetryWriter, TelemetryWriter>();
         }
 
         internal static void AddBodyLogger(IServiceCollection services, Action<BodyLoggerOptions> setupAction)

--- a/ApplicationInsightsRequestLogging/ApplicationInsightsRequestLogging/Reader/IBodyReader.cs
+++ b/ApplicationInsightsRequestLogging/ApplicationInsightsRequestLogging/Reader/IBodyReader.cs
@@ -10,5 +10,7 @@ namespace Azureblue.ApplicationInsights.RequestLogging
         public void PrepareResponseBodyReading(HttpContext context);
 
         public Task<string> ReadResponseBodyAsync(HttpContext context, int bytes, string appendix);
+
+        public Task RestoreOriginalResponseBodyStreamAsync(HttpContext context);
     }
 }


### PR DESCRIPTION
We ran into an error where the Verb is of interest but the returned status code wasnt, this would cause aspnet core to return a 500 error, and the console logs contained the following:

```
Microsoft.AspNetCore.Server.Kestrel: Error: Connection id "0HMDOPVCJFVGK", Request id "0HMDOPVCJFVGK:00000005": An unhandled exception was thrown by the application.

System.InvalidOperationException: Response Content-Length mismatch: too few bytes written (0 of 400).
```

This PR should correct the handling of `Verb of interest` + `Non-Interesting Http Status Code` by copying the original stream back to the `context.Response.Body`.